### PR TITLE
feat: Enable bot to respond without mentions

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -7,7 +7,9 @@ from slack_bolt.adapter.socket_mode import SocketModeHandler
 from slack import WebClient
 
 # LLM functions and objects
+from utils.config import MAP_MODEL_ID, MODEL
 from utils.llm_model import build_chain, add_chain_link, THREADS_DICT
+from utils.regex_funcs import re_get_mentions
 # Credentials
 load_dotenv()
 SLACK_BOT_TOKEN = os.environ["SLACK_BOT_TOKEN"]
@@ -24,7 +26,8 @@ logger = logging.getLogger(__name__)
 @app.message(".*")
 def message_handler(message: dict, say: slack_bolt.Say, logger: logging.Logger) -> None:
     """
-    Handles messages to chatbot within Apps
+    Listener for all messages in Apps and Channels
+        including messages to chatbot within Apps
     
     Parameters
     ----------
@@ -37,6 +40,21 @@ def message_handler(message: dict, say: slack_bolt.Say, logger: logging.Logger) 
     logger : logging.Logger
         logging object
     """
+    channel_type = message["channel_type"]
+    if channel_type == "im":
+        # All types of message permitted in Apps channels
+        pass
+    
+    else:
+        if "thread_ts" not in message or "bot_id" in message:
+            # Don't respond to non-mention if bot has not been mentioned before
+            # or message is addressed to another bot
+            return
+        # Mentions are handled by handle_app_mention_events()
+        mentions = re_get_mentions(message["text"])
+        if mentions:
+            return
+    
     # ID for channel message received from
     # Set thread timestamp as channel ID 
     try:
@@ -46,7 +64,11 @@ def message_handler(message: dict, say: slack_bolt.Say, logger: logging.Logger) 
     
     # If no chain exists for this channel, create new one
     if not channel_id in THREADS_DICT:
-        build_chain(channel_id)
+        if channel_type == "im":
+            build_chain(channel_id)
+        else:
+            # Don't join threads without mention
+            return
     
     # Store user_message and get bot response
     bot_message = add_chain_link(channel_id, message, loc="apps")
@@ -59,7 +81,7 @@ def message_handler(message: dict, say: slack_bolt.Say, logger: logging.Logger) 
 @app.event(("app_mention"))
 def handle_app_mention_events(body: dict, say: slack_bolt.Say, logger: logging.Logger) -> None:
     """
-    Handles direct (@) messages to chatbot within Channels
+    Creates new chain when bot first mentioned
     
     Parameters
     ----------
@@ -72,8 +94,15 @@ def handle_app_mention_events(body: dict, say: slack_bolt.Say, logger: logging.L
     logger : logging.Logger
         logging object
     """
+    # Ignore mentions that don't include this bot
+    mentions = re_get_mentions(body["event"]["text"])
+    model = MODEL.split("/")[1]
+    bot_id = MAP_MODEL_ID[model]
+    if bot_id not in mentions:
+        return
+    
     # ID for channel message received from
-    # Set thread timestamp as channel ID 
+    # Set thread timestamp as channel ID
     try:
         channel_id = body["event"]["thread_ts"]
     except KeyError:
@@ -82,7 +111,7 @@ def handle_app_mention_events(body: dict, say: slack_bolt.Say, logger: logging.L
     # If no chain exists for this channel, create new one
     if not channel_id in THREADS_DICT:
         build_chain(channel_id)
-    
+        
     # Store user_message and get bot response
     bot_message = add_chain_link(channel_id, body, loc="mentions")
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -14,7 +14,21 @@ TOP_K = 5
 TOP_P = 0.7
 REPETITION_PENALTY = 1.1
 
-# Not in use - for reference only
-CHATBOTS = {
-    "U06T5FVMMKL": "Yi-34B-Chat"
+MAP_ID_MODEL = {
+    "U06SZHDL487": "alpaca-7b", 
+    "U06U2UKPERE": "Llama-2-13b-chat-hf", 
+    "U06SZGFGNLF": "Mistral-7B-Instruct-v0.1", 
+    "U06T5FVMMKL": "Yi-34B-Chat",
+    "U06U9E0BGVC": "Intro-bot"
+}
+MAP_MODEL_ID = {
+    "alpaca-7b": "U06SZHDL487",
+    "Llama-2-13b-chat-hf": "U06U2UKPERE",
+    "Mistral-7B-Instruct-v0.1": "U06SZGFGNLF",
+    "Yi-34B-Chat": "U06T5FVMMKL", 
+    "Intro-bot": "U06U9E0BGVC"
+}
+
+DEVS = {
+    "U06PSGU9JJG": "ES",
 }

--- a/src/utils/llm_model.py
+++ b/src/utils/llm_model.py
@@ -4,7 +4,7 @@ import openai
 from dotenv import load_dotenv
 
 # Regex functions
-from utils.regex import regex_handler
+from utils.regex_funcs import regex_handler
 # Constants
 from utils.config import MODEL, MAX_TOKENS, TEMPERATURE, THREADS_DICT, TOP_P, VERBOSE
 from utils.system_prompt import SYSTEM_PROMPT

--- a/src/utils/regex_funcs.py
+++ b/src/utils/regex_funcs.py
@@ -2,10 +2,20 @@
 import re
 
 
+def re_get_mentions(raw_text: str) -> str:
+    """
+    Extracts user and bot mentions from message
+    """
+    pattern = r"<@([A-Z0-9]{9,11})>"
+    # Find all matches
+    matches = re.findall(pattern, raw_text)
+    
+    return matches
+
+
 def re_slack_id(raw_text: str) -> str:
     """
     Removes Slack user ID from start of message (if applicable)
-    Called by regex.regex_handler()
     """
     # Slack user ID format (optional colon and whitespace)
     pattern = r"(<@[A-Z0-9_]{9,11}>)"  
@@ -17,10 +27,19 @@ def re_slack_id(raw_text: str) -> str:
     return raw_text  
 
 
+def re_user_prefixes(raw_text: str) -> str:
+    """
+    Removes prefixes from printed message responses
+    """
+    # Remove "AI:" and "AI Assistant:" prefixes
+    clean_text = re.sub(r"^(AI\:|\s+AI Assistant\:)(.*)", r"\2", raw_text)
+    
+    return clean_text
+
+
 def re_whitespace(raw_text: str) -> str:
     """
     Converts whitespace characters to regular spaces
-    Called by regex.regex_handler()
     """
     # Replace all whitespace with single space
     clean_text = re.sub(r"\s+", " ", raw_text)
@@ -30,21 +49,9 @@ def re_whitespace(raw_text: str) -> str:
     return clean_text
 
 
-def re_user_prefixes(raw_text: str) -> str:
-    """
-    Removes prefixes from printed message responses
-    Called by regex.regex_handler()
-    """
-    # Remove "AI:" and "AI Assistant:" prefixes
-    clean_text = re.sub(r"^(AI\:|\s+AI Assistant\:)(.*)", r"\2", raw_text)
-    
-    return clean_text
-
-
 def regex_handler(raw_text: str) -> str:
     """
     Passes user and bot messages to regex functions
-    Called by llm_model.add_chain_link()
     """
     rgx_msg = re_slack_id(raw_text)
     rgx_msg = re_whitespace(rgx_msg)


### PR DESCRIPTION
Functionality added for bot so that it:

In Apps:
- responds to all messages, whether mentioned or not

In Public Channels:
- responds in channel by creating a new thread when mentioned
- responds in threads when mentioned or not, except for messages that have mentions not including the bot

In Private Channels:
- responds in channel by creating a new thread when mentioned
- responds in thread only to mentions